### PR TITLE
Removed unused orange color stats

### DIFF
--- a/stats/index.html
+++ b/stats/index.html
@@ -28,9 +28,9 @@ title: Stats
 					<li class="collection-item green">
 						<h5>Green indicates the service is supported by RiiConnect24.</h5>
 					</li>
-					<li class="collection-item yellow">
+					<!--li class="collection-item yellow">
 						<h5>Yellow indicates that we're working on support for the service, but it has not been released yet.</h5>
-					</li>
+					</li>-->
 					<li class="collection-item orange">
 						<h5>Orange indicates that some extra information will be required to support the service, but we aim to make it work at some point.</h5>
 					</li>


### PR DESCRIPTION
Since shutterbug2000 make progres on mii contest channel we not nead the orange stats color as of now