### PR TITLE
Update digicam service (mark as available thanks to WL24 + reorder)

### DIFF
--- a/services/digicam.html
+++ b/services/digicam.html
@@ -7,7 +7,7 @@ title: Digicam Print Channel
       <br><br>
       <h1 class="header center white-text"><i class="fas fa-camera" aria-hidden="true"></i> Digicam Print Channel</h1>
       <div class="row center">
-      	<h5 class="header col s12 light">This service is currently being worked on thanks to <a href="https://www.wiilink24.com">WiiLink24</a>.</h5>
+      	<h5 class="header col s12 light">This service has been brought back thanks to <a href="https://www.wiilink24.com">WiiLink24</a>.</h5>
         <img src="/images/wiimenu/digicam.png" alt="Digicam" />
       </div>
       <audio autoplay>

--- a/stats/index.html
+++ b/stats/index.html
@@ -91,11 +91,11 @@ title: Stats
 					<li class="collection-item green">
 						<h5><a href="/services/speak.html" class="blue-text text-darken-4">Wii Speak Channel</a></h5>
 					</li>
-					<li class="collection-item yellow">
-						<h5><a href="/services/food.html" class="blue-text text-darken-4">Demae Channel</a></h5>
+					<li class="collection-item green">
+						<h5><a href="/services/digicam.html" class="blue-text text-darken-4">Digicam Print Channel</a></h5>
 					</li>
 					<li class="collection-item yellow">
-						<h5><a href="/services/digicam.html" class="blue-text text-darken-4">Digicam Print Channel</a></h5>
+						<h5><a href="/services/food.html" class="blue-text text-darken-4">Demae Channel</a></h5>
 					</li>
 					<li class="collection-item orange">
 						<h5><a href="/services/television.html" class="blue-text text-darken-4">TV no Tomo Channel G Guide for Wii</a></h5>


### PR DESCRIPTION
* Mark services/digicram.html's title as saying that the service has 
been brought back
* Change the stats/index.html entry for Digicam to green and reorder it 
(so it makes sense/looks good)

---------------------
(not part of PR message) closes https://discord.com/channels/206934458954153984/258999527783137280/846420494084603955 :kekw: