### PR TITLE
Fix `How to Connect` link pointing to index of wii.guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ title: RiiConnect24
 			<h1 class="header center white-text">RiiConnect your Wii.</h1>
 			<div class="row center">
         <h5 class="header col s12 light white-text center">RiiConnect24 brings back WiiConnect24, making your Wii more lively.</h5>
-				<a href="https://wii.guide/" id="download-button" class="btn-large waves-effect waves-light blue lighten-1">How to Connect</a>
+				<a href="https://wii.guide/riiconnect24" id="download-button" class="btn-large waves-effect waves-light blue lighten-1">How to Connect</a>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This just changes the index page instead of pointing to wii.guide's index page, to point straight to the rc24 page (as that is where it should redirect to).