### PR TITLE
CSS refactoring

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
 	<div class="container">
 		<div class="row">
 			<div class="col l6 s12">
-				<h5 class="white-text"><i class="fas fa-info-circle" aria-hidden"true"></i> About RiiConnect24</h5>
+				<h5><i class="fas fa-info-circle" aria-hidden"true"></i> About RiiConnect24</h5>
 				<p class="grey-text text-lighten-4">
 					RiiConnect24 lets you use the defunct WiiConnect24 service on your Wii once again, allowing you to
 					use the
@@ -14,34 +14,34 @@
 				</p>
 			</div>
 			<div class="col l3 s12">
-				<h5 class="white-text"><i class="fas fa-share-square" aria-hidden="true"></i> Connect with Us</h5>
+				<h5><i class="fas fa-share-square" aria-hidden="true"></i> Connect with Us</h5>
 				<ul>
-					<li><i class="fas fa-cloud" aria-hidden="true"></i> <a class="white-text"
-							href="https://bsky.app/profile/riiconnect24.bsky.social">Bluesky</a></li>
-					<li><i class="fab fa-discord" aria-hidden="true"></i> <a class="white-text"
-							href="https://discord.gg/rc24">Discord</a></li>
-					<li><i class="fab fa-instagram" aria-hidden="true"></i> <a class="white-text"
-							href="https://www.instagram.com/RiiConnect24">Instagram</a></li>
-					<li><i class="fab fa-mastodon" aria-hidden="true"></i> <a class="white-text"
-							href="https://mastodon.social/@RiiConnect24">Mastodon</a></li>
-					<li><i class="fab fa-github" aria-hidden="true"></i> <a class="white-text"
-							href="https://github.com/RiiConnect24">GitHub</a></li>
-					<li><i class="fab fa-reddit" aria-hidden="true"></i> <a class="white-text"
-							href="https://reddit.com/r/RiiConnect24">Reddit</a></li>
-					<li><i class="fab fa-threads" aria-hidden="true"></i> <a class="white-text"
-							href="https://threads.net/@riiconnect24">Threads</a></li>
-					<li><i class="fab fa-youtube" aria-hidden="true"></i> <a class="white-text"
-							href="https://www.youtube.com/RiiConnect24">YouTube</a></li>
+					<li><i class="fas fa-cloud" aria-hidden="true"></i>
+						<a href="https://bsky.app/profile/riiconnect24.bsky.social">Bluesky</a></li>
+					<li><i class="fab fa-discord" aria-hidden="true"></i>
+						<a href="https://discord.gg/rc24">Discord</a></li>
+					<li><i class="fab fa-instagram" aria-hidden="true"></i>
+						<a href="https://www.instagram.com/RiiConnect24">Instagram</a></li>
+					<li><i class="fab fa-mastodon" aria-hidden="true"></i>
+						<a href="https://mastodon.social/@RiiConnect24">Mastodon</a></li>
+					<li><i class="fab fa-github" aria-hidden="true"></i>
+						<a href="https://github.com/RiiConnect24">GitHub</a></li>
+					<li><i class="fab fa-reddit" aria-hidden="true"></i>
+						<a href="https://reddit.com/r/RiiConnect24">Reddit</a></li>
+					<li><i class="fab fa-threads" aria-hidden="true"></i>
+						<a href="https://threads.net/@riiconnect24">Threads</a></li>
+					<li><i class="fab fa-youtube" aria-hidden="true"></i>
+						<a href="https://www.youtube.com/RiiConnect24">YouTube</a></li>
 				</ul>
 			</div>
 			<div class="col l3 s12">
-				<h5 class="white-text"><i class="fas fa-puzzle-piece" aria-hidden="true"></i> Affiliate Projects</h5>
+				<h5><i class="fas fa-puzzle-piece" aria-hidden="true"></i> Affiliate Projects</h5>
 				<ul>
-					<li><a class="white-text" href="https://gametdb.com/">GameTDB</a></li>
-					<li><a class="white-text" href="https://oscwii.org/">Open Shop Channel</a></li>
-					<li><a class="white-text" href="https://wiidatabase.de/">WiiDatabase</a></li>
-					<li><a class="white-text" href="https://wiilink24.com/">WiiLink</a></li>
-					<li><a class="white-text" href="https://wiimmfi.de/">Wiimmfi</a></li>
+					<li><a href="https://gametdb.com/">GameTDB</a></li>
+					<li><a href="https://oscwii.org/">Open Shop Channel</a></li>
+					<li><a href="https://wiidatabase.de/">WiiDatabase</a></li>
+					<li><a href="https://wiilink24.com/">WiiLink</a></li>
+					<li><a href="https://wiimmfi.de/">Wiimmfi</a></li>
 				</ul>
 			</div>
 		</div>

--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@ title: About
 	<div class="container">
 		<br>
 		<br>
-		<h1 class="header center white-text"><i aria-hidden="true" class="fas fa-info-circle"></i> About Us</h1><br>
+		<h1 class="header center"><i aria-hidden="true" class="fas fa-info-circle"></i> About Us</h1><br>
 		<br>
 	</div>
 </div>
@@ -21,12 +21,12 @@ title: About
 <div class="section">
 	<div class="container">
 		<div class="row center">
-			<h2 class="header center white-text"><i aria-hidden="true" class="fas fa-timeline"></i> Timeline</h2><br>
+			<h2 class="header center"><i aria-hidden="true" class="fas fa-timeline"></i> Timeline</h2><br>
 			<div class="timeline">
 				<div class="timeline-event">
 					<div class="card timeline-content">
-						<div class="card-content blue white-text">
-							<span class="card-title white-text text-darken-4">
+						<div class="card-content blue">
+							<span class="card-title text-darken-4">
 								August 6, 2015<br>
 							</span>
 							<p>RiiConnect24 was established.</p>
@@ -35,8 +35,8 @@ title: About
 				</div>
 				<div class="timeline-event">
 					<div class="card timeline-content">
-						<div class="card-content blue white-text">
-							<span class="card-title  white-text text-darken-4">
+						<div class="card-content blue">
+							<span class="card-title  text-darken-4">
 								July 28, 2016<br>
 							</span>
 							<p>Revival of News Channel released.</p>
@@ -45,8 +45,8 @@ title: About
 				</div>
 				<div class="timeline-event">
 					<div class="card timeline-content">
-						<div class="card-content blue white-text">
-							<span class="card-title  white-text text-darken-4">
+						<div class="card-content blue">
+							<span class="card-title  text-darken-4">
 								December 3, 2016<br>
 							</span>
 							<p>Revival of Wii Mail released.</p>
@@ -55,8 +55,8 @@ title: About
 				</div>
 				<div class="timeline-event">
 					<div class="card timeline-content">
-						<div class="card-content blue white-text">
-							<span class="card-title  white-text text-darken-4">
+						<div class="card-content blue">
+							<span class="card-title  text-darken-4">
 								December 19, 2016<br>
 							</span>
 							<p>Revival of Forecast Channel released.</p>
@@ -65,8 +65,8 @@ title: About
 				</div>
 				<div class="timeline-event">
 					<div class="card timeline-content">
-						<div class="card-content blue white-text">
-							<span class="card-title white-text text-darken-4">
+						<div class="card-content blue">
+							<span class="card-title text-darken-4">
 								December 2, 2017<br>
 							</span>
 							<p>Revival of Everybody Votes Channel released.</p>
@@ -75,8 +75,8 @@ title: About
 				</div>
 				<div class="timeline-event">
 					<div class="card timeline-content">
-						<div class="card-content blue white-text">
-							<span class="card-title white-text text-darken-4">
+						<div class="card-content blue">
+							<span class="card-title text-darken-4">
 								February 10, 2019<br>
 							</span>
 							<p>Revival of Nintendo Channel released.</p>
@@ -85,8 +85,8 @@ title: About
 				</div>
 				<div class="timeline-event">
 					<div class="card timeline-content">
-						<div class="card-content blue white-text">
-							<span class="card-title white-text text-darken-4">
+						<div class="card-content blue">
+							<span class="card-title text-darken-4">
 								December 2, 2019<br>
 							</span>
 							<p>Revival of Check Mii Out Channel released.</p>
@@ -95,8 +95,8 @@ title: About
 				</div>
 				<div class="timeline-event">
 					<div class="card timeline-content">
-						<div class="card-content blue white-text">
-							<span class="card-title white-text text-darken-4">
+						<div class="card-content blue">
+							<span class="card-title text-darken-4">
 								March 6, 2020<br>
 							</span>
 							<p>Revival of RiiTag released.</p>

--- a/about.html
+++ b/about.html
@@ -36,7 +36,7 @@ title: About
 				<div class="timeline-event">
 					<div class="card timeline-content">
 						<div class="card-content blue">
-							<span class="card-title  text-darken-4">
+							<span class="card-title text-darken-4">
 								July 28, 2016<br>
 							</span>
 							<p>Revival of News Channel released.</p>
@@ -46,7 +46,7 @@ title: About
 				<div class="timeline-event">
 					<div class="card timeline-content">
 						<div class="card-content blue">
-							<span class="card-title  text-darken-4">
+							<span class="card-title text-darken-4">
 								December 3, 2016<br>
 							</span>
 							<p>Revival of Wii Mail released.</p>
@@ -56,7 +56,7 @@ title: About
 				<div class="timeline-event">
 					<div class="card timeline-content">
 						<div class="card-content blue">
-							<span class="card-title  text-darken-4">
+							<span class="card-title text-darken-4">
 								December 19, 2016<br>
 							</span>
 							<p>Revival of Forecast Channel released.</p>

--- a/branding.html
+++ b/branding.html
@@ -5,13 +5,13 @@ title: Branding
 	<div class="container">
 		<br>
 		<br>
-		<h1 class="header center white-text"><i aria-hidden="true" class="fas fa-palette"></i> Branding</h1><br>
+		<h1 class="header center"><i aria-hidden="true" class="fas fa-palette"></i> Branding</h1><br>
 		<br>
 	</div>
 </div>
 <div class="section">
 	<div class="container">
-		<h2 class="header center white-text">Logos</h2>
+		<h2 class="header center">Logos</h2>
 		<div class="row">
 			<div class="col l6">
 				<div class="card">
@@ -83,18 +83,16 @@ title: Branding
 				</div>
 			</div>
 		</div>
-		<h2 class="header center white-text">Color</h2>
+		<h2 class="header center">Color</h2>
 		<div class="row">
-			<div class="col s3">
+			<div class="col">
 				<div class="card" style="background-color: #1eb5ec !important">
 					<div class="card-content">
-						<span class="white-text">
-							<span class="card-title">RiiConnect24 Blue</span>
-							<br><br><br><br><br>
-							#18B6ED
-							<br>
-							CMYK: 68, 8, 0, 0
-						</span>
+						<span class="card-title">RiiConnect24 Blue</span>
+						<br><br><br><br><br>
+						#18B6ED
+						<br>
+						CMYK: 68, 8, 0, 0
 					</div>
 				</div>
 			</div>

--- a/css/style.css
+++ b/css/style.css
@@ -12,19 +12,15 @@ html {
   font-family: 'Open Sans', sans-serif;
   font-size: 17px;
   cursor: url("https://rc24.xyz/images/cursors/wii.cur"), default;
-  color: #c0c0c0 !important;
+  color: #c0c0c0;
 }
 
 body {
   color: #000;
 }
 
-.white-text {
-  color: unset !important;
-}
-
 .header {
-  color: #2196F3 !important;
+  color: #2196F3;
 }
 
 .light {
@@ -36,19 +32,19 @@ body {
 
 @media (prefers-color-scheme: dark) {
   html {
-    background: #333 !important;
-  }
-
-  .white-text {
-    color: #fff !important;
-  }
-
-  .light {
-    color: #fff !important;
+    background: #333;
   }
 
   body {
-    color: #fff !important;
+    color: #fff;
+  }
+
+  .light {
+    color: #fff;
+  }
+
+  .header {
+    color: #fff;
   }
 
   .collection .collection-item {
@@ -62,12 +58,8 @@ body {
   }
 
   .card {
-    background-color: #222 !important;
+    background-color: #222;
   }
-}
-
-.collection.with-header h5 {
-  color: #000;
 }
 
 .actually-red {
@@ -76,7 +68,7 @@ body {
 
 a {
   color: #00b0f4;
-  cursor: url("https://rc24.xyz/images/cursors/wii-hover.cur"), default !important;
+  cursor: url("https://rc24.xyz/images/cursors/wii-hover.cur"), pointer;
 }
 
 .collection {
@@ -131,6 +123,9 @@ p {
 
 .page-footer {
   margin: 0;
+  a {
+    color: #fff;
+  }
 }
 
 .full-height {

--- a/css/style.css
+++ b/css/style.css
@@ -106,11 +106,6 @@ a {
   background: #222;
 }
 
-nav ul a,
-nav .brand-logo {
-  /*  color: #444;*/
-}
-
 p {
   line-height: 2rem;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -283,9 +283,7 @@ p {
     position: absolute;
     bottom: 0px;
     padding-bottom: 64px;
-    display: block;
     width: 100%;
-    background-color: rgba(0, 0, 0, 0);
     background: linear-gradient(to bottom, rgba(125, 185, 232, 0) 0%, rgba(0, 0, 0, 0.4) 50%, rgba(0, 0, 0, 0.8) 100%);
   }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -11,7 +11,6 @@
 html {
   font-family: 'Open Sans', sans-serif;
   font-size: 17px;
-  overflow: scroll;
   cursor: url("https://rc24.xyz/images/cursors/wii.cur"), default;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -309,7 +309,6 @@ p {
 }
 
 .card-title {
-  // font-weight: 600!important;
   line-height: 1em;
 
   &.gradient {

--- a/css/style.css
+++ b/css/style.css
@@ -12,8 +12,8 @@ html {
   font-family: 'Open Sans', sans-serif;
   font-size: 17px;
   cursor: url("https://rc24.xyz/images/cursors/wii.cur"), default;
+  color: #c0c0c0 !important;
 }
-
 
 body {
   color: #000;
@@ -64,29 +64,6 @@ body {
   .card {
     background-color: #222 !important;
   }
-}
-
-@media (prefers-color-scheme: light) {
-  body {
-    color: #000;
-  }
-
-  .white-text {
-    color: unset !important;
-  }
-
-  .header {
-    color: #2196F3 !important;
-  }
-
-  .light {
-    color: #000;
-    /* yes I know this ain't white */
-  }
-}
-
-html {
-  color: #c0c0c0 !important;
 }
 
 .collection.with-header h5 {

--- a/dns.html
+++ b/dns.html
@@ -5,7 +5,7 @@ title: DNS Change
     <div class="container">
         <br>
         <br>
-        <h1 class="header center white-text"><i aria-hidden="true" class="fas fa-info-circle"></i> DNS Change</h1><br>
+        <h1 class="header center"><i aria-hidden="true" class="fas fa-info-circle"></i> DNS Change</h1><br>
         <br>
     </div>
 </div>

--- a/donation.html
+++ b/donation.html
@@ -4,9 +4,9 @@ title: Donations
 <div class="section no-pad-bot">
 	<div class="container">
 		<br><br>
-		<h1 class="header center white-text"><i class="fas fa-money-bill-alt" aria-hidden="true"></i> Donations</h1>
+		<h1 class="header center"><i class="fas fa-money-bill-alt" aria-hidden="true"></i> Donations</h1>
 		<div class="row center">
-			<h5 class="header col s12 light">RiiConnect24 accepts donations. The donations will be used for paying for server and domain costs.</h5>
+			<h5 class="header col s12">RiiConnect24 accepts donations. The donations will be used for paying for server and domain costs.</h5>
 			<br>
 			<a href="https://www.paypal.me/RiiConnect" target="_blank">
 				<img alt="Donate via PayPal" src="/images/paypal-donate.png">

--- a/faq.html
+++ b/faq.html
@@ -5,7 +5,7 @@ title: FAQ
 	<div class="container">
 		<br>
 		<br>
-		<h1 class="header center white-text"><i aria-hidden="true" class="fas fa-question-circle"></i> FAQ</h1><br>
+		<h1 class="header center"><i aria-hidden="true" class="fas fa-question-circle"></i> FAQ</h1><br>
 		<br>
 	</div>
 </div>

--- a/goodies/cat/index.html
+++ b/goodies/cat/index.html
@@ -4,7 +4,7 @@ title: "Nyan Help Cat"
 ---
 	<div class="section no-pad-bot">
 		<div class="container center">
-			<h1 class="header white-text"><i class="fas fa-cat" aria-hidden="true"></i> Nyan Help Cat</h1>
+			<h1 class="header"><i class="fas fa-cat" aria-hidden="true"></i> Nyan Help Cat</h1>
 			<iframe width="560" height="315" src="https://www.youtube.com/embed/pc1PWfcYlKo?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 		</div>
 	</div>

--- a/goodies/index.html
+++ b/goodies/index.html
@@ -4,9 +4,9 @@ title: Goodies
 	<div class="section no-pad-bot">
 		<div class="container">
 			<br><br>
-			<h1 class="header center white-text"><i class="fas fa-gift" aria-hidden="true"></i> Goodies</h1>
+			<h1 class="header center"><i class="fas fa-gift" aria-hidden="true"></i> Goodies</h1>
 			<div class="row center">
-				<h5 class="header col s12 light">Here's some cool stuff that we put together. Enjoy.</h5>
+				<h5 class="header col s12">Here's some cool stuff that we put together. Enjoy.</h5>
 			</div>
 			<br><br>
 		</div>

--- a/goodies/mii/index.html
+++ b/goodies/mii/index.html
@@ -5,19 +5,19 @@ title: My Avatar Editor
 	<div class="section no-pad-bot">
 		<div class="container">
 			<br><br>
-			<h1 class="header center white-text"><i class="fas fa-smile" aria-hidden="true"></i> My Avatar Editor</h1>
+			<h1 class="header center"><i class="fas fa-smile" aria-hidden="true"></i> My Avatar Editor</h1>
 			<div class="row center">
-				<h5 class="header col s12 light">You can use this tool called My Avatar Editor to make and edit Miis. It runs on Adobe Flash, which was discontinued at the end of 2020. However, there are still a few ways to use it.</h5>
-				<h5 class="header col s12 light">Check out <a href="https://mii.rc24.xyz/">mii.rc24.xyz</a> for more Mii content!</h5>
+				<h5 class="header col s12">You can use this tool called My Avatar Editor to make and edit Miis. It runs on Adobe Flash, which was discontinued at the end of 2020. However, there are still a few ways to use it.</h5>
+				<h5 class="header col s12">Check out <a href="https://mii.rc24.xyz/">mii.rc24.xyz</a> for more Mii content!</h5>
 			</div>
 			<br><br>
 		</div>
 	</div>
 	<div class="section">
 		<div class="container">
-			<h3 class="header center white-text"><i class="fas fa-desktop"></i> Install for Desktop</h2>
+			<h3 class="header center"><i class="fas fa-desktop"></i> Install for Desktop</h2>
 			<div class="row center">
-				<h6 class="header col s12 light">It's possible to install My Avatar Editor on your computer as an application. Follow these instructions:</h5>
+				<h6 class="header col s12">It's possible to install My Avatar Editor on your computer as an application. Follow these instructions:</h5>
 			</div>
 			<ol class="collection">
 				<li class="collection-item">Download and install Adobe AIR. (<a href="http://web.archive.org/web/20201217075800/https://fpdownload.macromedia.com/pub/labs/flashruntimes/air/AdobeAIR.dmg"><i class="fab fa-apple"></i> macOS</a> / <a href="http://web.archive.org/web/20201217075810/https://fpdownload.macromedia.com/pub/labs/flashruntimes/air/AdobeAIRInstaller.exe"><i class="fab fa-windows"></i> Windows</a>) AIR is discontinued by Adobe, but it's still possible to use it.</li>
@@ -31,17 +31,17 @@ title: My Avatar Editor
 	</div>
 	<div class="section">
 		<div class="container">
-			<h3 class="header center white-text"><i class="fas fa-bolt"></i> Flashpoint</h2>
+			<h3 class="header center"><i class="fas fa-bolt"></i> Flashpoint</h2>
 			<div class="row center">
-				<h6 class="header col s12 light">You can use BlueMaxima's Flashpoint to use My Avatar Editor again. It's a project to preserve old Flash games. For more information, <a href="https://bluemaxima.org/flashpoint/">please see the official Flashpoint website</a>.</h5>
+				<h6 class="header col s12">You can use BlueMaxima's Flashpoint to use My Avatar Editor again. It's a project to preserve old Flash games. For more information, <a href="https://bluemaxima.org/flashpoint/">please see the official Flashpoint website</a>.</h5>
 			</div>
 		</div>
 	</div>
 	<div class="section">
 		<div class="container">
-			<h3 class="header center white-text"><i class="fas fa-globe-americas"></i> Use in Browser</h2>
+			<h3 class="header center"><i class="fas fa-globe-americas"></i> Use in Browser</h2>
 			<div class="row center">
-				<h6 class="header center white-text">This won't load nor show up unless you're somehow using a legacy browser. (It will work with SeaMonkey)</h5>
+				<h6 class="header center">This won't load nor show up unless you're somehow using a legacy browser. (It will work with SeaMonkey)</h5>
 			
 				<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/swfobject/2.2/swfobject.min.js"></script>
 				<script type="text/javascript" src="utils.js"></script>

--- a/goodies/photochannel/index.html
+++ b/goodies/photochannel/index.html
@@ -5,9 +5,9 @@ title: Photo Channel Puzzle Cheats
 	<div class="section no-pad-bot">
 		<div class="container">
 			<br><br>
-			<h1 class="header center white-text"><i class="fas fa-download" aria-hidden="true"></i> Photo Channel Puzzle Cheats</h1>
+			<h1 class="header center"><i class="fas fa-download" aria-hidden="true"></i> Photo Channel Puzzle Cheats</h1>
 			<div class="row center">
-				<h5 class="header col s12 light">These are intended to help get fast puzzle records on the Photo Channel, every number on the puzzle piece corresponds to where it fits.</h5>
+				<h5 class="header col s12">These are intended to help get fast puzzle records on the Photo Channel, every number on the puzzle piece corresponds to where it fits.</h5>
 			  <a href="puzzle_all.zip" id="download-button" class="btn-large waves-effect waves-light blue lighten-1">Download Puzzle Cheats</a>
 			</div>
       <audio autoplay>

--- a/goodies/ring/index.html
+++ b/goodies/ring/index.html
@@ -4,7 +4,7 @@ title: "Wii Shop Channel with Lyrics"
 ---
 	<div class="section no-pad-bot">
 		<div class="container center">
-			<h1 class="header white-text"><i class="fas fa-shopping-basket" aria-hidden="true"></i> Wii Shop Channel with Lyrics</h1>
+			<h1 class="header"><i class="fas fa-shopping-basket" aria-hidden="true"></i> Wii Shop Channel with Lyrics</h1>
 			<iframe width="560" height="315" src="https://www.youtube.com/embed/3ruNfajgUr0?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 			<br>
 			<img class="spin" src="/images/wiimenu/ring.png" alt="Wii Shop Channel Ring">

--- a/goodies/strips/index.html
+++ b/goodies/strips/index.html
@@ -5,9 +5,9 @@ title: Comic Strips Gallery
 	<div class="section no-pad-bot">
 		<div class="container">
 			<br><br>
-			<h1 class="header center white-text"><i class="fas fa-book" aria-hidden="true"></i> Comic Strips Gallery</h1>
+			<h1 class="header center"><i class="fas fa-book" aria-hidden="true"></i> Comic Strips Gallery</h1>
 			<div class="row center">
-				<h5 class="header col s12 light">You can view a collection of stupid comic strips featuring RiiConnect24 developers here.</h5>
+				<h5 class="header col s12">You can view a collection of stupid comic strips featuring RiiConnect24 developers here.</h5>
 			</div>
 			<br><br>
 		</div>
@@ -124,4 +124,5 @@ title: Comic Strips Gallery
 		      </div>
 		    </div>
 		  </div>
+    </div>
 	</div>

--- a/goodies/themes/index.html
+++ b/goodies/themes/index.html
@@ -5,11 +5,11 @@ title: Theme Downloads
 <div class="section no-pad-bot">
 	<div class="container">
 		<br><br>
-		<h1 class="header center white-text"><i class="fas fa-download" aria-hidden="true"></i> Theme Downloads</h1>
+		<h1 class="header center"><i class="fas fa-download" aria-hidden="true"></i> Theme Downloads</h1>
 		<div class="row center">
-			<h5 class="header col s12 light">Here's some themes for you to download.</h5>
+			<h5 class="header col s12">Here's some themes for you to download.</h5>
 			<br>
-			<h5 class="header col s12 light">Also check out <a href="https://theme.rc24.xyz/">theme.rc24.xyz</a> for more themes.</h5>
+			<h5 class="header col s12">Also check out <a href="https://theme.rc24.xyz/">theme.rc24.xyz</a> for more themes.</h5>
 		</div>
 		<br><br>
 	</div>

--- a/goodies/vote/001_japanese_results.html
+++ b/goodies/vote/001_japanese_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Japan Japanese Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-jp"></span> Japan Japanese Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-jp"></span> Japan Japanese Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/010_english_results.html
+++ b/goodies/vote/010_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Argentina English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ar"></span> Argentina English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ar"></span> Argentina English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/010_french_results.html
+++ b/goodies/vote/010_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Argentina French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ar"></span> Argentina French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ar"></span> Argentina French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/010_spanish_results.html
+++ b/goodies/vote/010_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Argentina Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ar"></span> Argentina Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ar"></span> Argentina Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/016_english_results.html
+++ b/goodies/vote/016_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Brazil English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-br"></span> Brazil English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-br"></span> Brazil English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/016_french_results.html
+++ b/goodies/vote/016_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Brazil French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-br"></span> Brazil French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-br"></span> Brazil French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/016_portuguese_results.html
+++ b/goodies/vote/016_portuguese_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Brazil Portuguese Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-br"></span> Brazil Portuguese Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-br"></span> Brazil Portuguese Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/016_spanish_results.html
+++ b/goodies/vote/016_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Brazil Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-br"></span> Brazil Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-br"></span> Brazil Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/018_english_results.html
+++ b/goodies/vote/018_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Canada English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ca"></span> Canada English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ca"></span> Canada English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/018_french_results.html
+++ b/goodies/vote/018_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Canada French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ca"></span> Canada French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ca"></span> Canada French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/018_spanish_results.html
+++ b/goodies/vote/018_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Canada Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ca"></span> Canada Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ca"></span> Canada Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/020_english_results.html
+++ b/goodies/vote/020_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Chile English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-cl"></span> Chile English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-cl"></span> Chile English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/020_french_results.html
+++ b/goodies/vote/020_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Chile French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-cl"></span> Chile French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-cl"></span> Chile French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/020_spanish_results.html
+++ b/goodies/vote/020_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Chile Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-cl"></span> Chile Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-cl"></span> Chile Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/021_english_results.html
+++ b/goodies/vote/021_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Colombia English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-co"></span> Colombia English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-co"></span> Colombia English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/021_french_results.html
+++ b/goodies/vote/021_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Colombia French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-co"></span> Colombia French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-co"></span> Colombia French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/021_spanish_results.html
+++ b/goodies/vote/021_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Colombia Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-co"></span> Colombia Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-co"></span> Colombia Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/022_english_results.html
+++ b/goodies/vote/022_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Costa Rica English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-cr"></span> Costa Rica English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-cr"></span> Costa Rica English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/022_french_results.html
+++ b/goodies/vote/022_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Costa Rica French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-cr"></span> Costa Rica French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-cr"></span> Costa Rica French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/022_spanish_results.html
+++ b/goodies/vote/022_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Costa Rica Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-cr"></span> Costa Rica Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-cr"></span> Costa Rica Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/025_english_results.html
+++ b/goodies/vote/025_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Ecuador English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ec"></span> Ecuador English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ec"></span> Ecuador English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/025_french_results.html
+++ b/goodies/vote/025_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Ecuador French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ec"></span> Ecuador French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ec"></span> Ecuador French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/025_spanish_results.html
+++ b/goodies/vote/025_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Ecuador Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ec"></span> Ecuador Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ec"></span> Ecuador Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/030_english_results.html
+++ b/goodies/vote/030_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Guatemala English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-gt"></span> Guatemala English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-gt"></span> Guatemala English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/030_french_results.html
+++ b/goodies/vote/030_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Guatemala French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-gt"></span> Guatemala French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-gt"></span> Guatemala French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/030_spanish_results.html
+++ b/goodies/vote/030_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Guatemala Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-gt"></span> Guatemala Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-gt"></span> Guatemala Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/036_english_results.html
+++ b/goodies/vote/036_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Mexico English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-mx"></span> Mexico English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-mx"></span> Mexico English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/036_french_results.html
+++ b/goodies/vote/036_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Mexico French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-mx"></span> Mexico French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-mx"></span> Mexico French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/036_spanish_results.html
+++ b/goodies/vote/036_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Mexico Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-mx"></span> Mexico Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-mx"></span> Mexico Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/040_english_results.html
+++ b/goodies/vote/040_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Panama English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-pa"></span> Panama English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-pa"></span> Panama English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/040_french_results.html
+++ b/goodies/vote/040_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Panama French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-pa"></span> Panama French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-pa"></span> Panama French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/040_spanish_results.html
+++ b/goodies/vote/040_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Panama Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-pa"></span> Panama Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-pa"></span> Panama Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/042_english_results.html
+++ b/goodies/vote/042_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Peru English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-pe"></span> Peru English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-pe"></span> Peru English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/042_french_results.html
+++ b/goodies/vote/042_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Peru French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-pe"></span> Peru French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-pe"></span> Peru French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/042_spanish_results.html
+++ b/goodies/vote/042_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Peru Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-pe"></span> Peru Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-pe"></span> Peru Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/049_english_results.html
+++ b/goodies/vote/049_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - United States English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-us"></span> United States English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-us"></span> United States English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/049_french_results.html
+++ b/goodies/vote/049_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - United States French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-us"></span> United States French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-us"></span> United States French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/049_spanish_results.html
+++ b/goodies/vote/049_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - United States Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-us"></span> United States Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-us"></span> United States Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/052_english_results.html
+++ b/goodies/vote/052_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Venezuela English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ve"></span> Venezuela English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ve"></span> Venezuela English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/052_french_results.html
+++ b/goodies/vote/052_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Venezuela French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ve"></span> Venezuela French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ve"></span> Venezuela French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/052_spanish_results.html
+++ b/goodies/vote/052_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Venezuela Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ve"></span> Venezuela Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ve"></span> Venezuela Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/065_english_results.html
+++ b/goodies/vote/065_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Australia English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-au"></span> Australia English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-au"></span> Australia English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/066_dutch_results.html
+++ b/goodies/vote/066_dutch_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Austria Dutch Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-at"></span> Austria Dutch Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-at"></span> Austria Dutch Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/066_french_results.html
+++ b/goodies/vote/066_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Austria French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-at"></span> Austria French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-at"></span> Austria French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/066_german_results.html
+++ b/goodies/vote/066_german_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Austria German Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-at"></span> Austria German Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-at"></span> Austria German Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/066_italian_results.html
+++ b/goodies/vote/066_italian_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Austria Italian Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-at"></span> Austria Italian Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-at"></span> Austria Italian Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/067_dutch_results.html
+++ b/goodies/vote/067_dutch_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Belgium Dutch Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-be"></span> Belgium Dutch Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-be"></span> Belgium Dutch Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/067_french_results.html
+++ b/goodies/vote/067_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Belgium French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-be"></span> Belgium French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-be"></span> Belgium French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/067_german_results.html
+++ b/goodies/vote/067_german_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Belgium German Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-be"></span> Belgium German Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-be"></span> Belgium German Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/067_italian_results.html
+++ b/goodies/vote/067_italian_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Belgium Italian Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-be"></span> Belgium Italian Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-be"></span> Belgium Italian Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/074_english_results.html
+++ b/goodies/vote/074_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Denmark English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-dk"></span> Denmark English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-dk"></span> Denmark English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/076_english_results.html
+++ b/goodies/vote/076_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Finland English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-fi"></span> Finland English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-fi"></span> Finland English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/077_french_results.html
+++ b/goodies/vote/077_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - France French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-fr"></span> France French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-fr"></span> France French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/078_german_results.html
+++ b/goodies/vote/078_german_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Germany German Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-de"></span> Germany German Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-de"></span> Germany German Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/079_english_results.html
+++ b/goodies/vote/079_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Greece English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-gr"></span> Greece English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-gr"></span> Greece English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/079_portuguese_results.html
+++ b/goodies/vote/079_portuguese_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Greece Portuguese Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-gr"></span> Greece Portuguese Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-gr"></span> Greece Portuguese Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/079_spanish_results.html
+++ b/goodies/vote/079_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Greece Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-gr"></span> Greece Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-gr"></span> Greece Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/082_english_results.html
+++ b/goodies/vote/082_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Ireland English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ie"></span> Ireland English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ie"></span> Ireland English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/083_italian_results.html
+++ b/goodies/vote/083_italian_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Italy Italian Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-it"></span> Italy Italian Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-it"></span> Italy Italian Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/088_dutch_results.html
+++ b/goodies/vote/088_dutch_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Luxembourg Dutch Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-lu"></span> Luxembourg Dutch Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-lu"></span> Luxembourg Dutch Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/088_french_results.html
+++ b/goodies/vote/088_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Luxembourg French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-lu"></span> Luxembourg French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-lu"></span> Luxembourg French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/088_german_results.html
+++ b/goodies/vote/088_german_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Luxembourg German Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-lu"></span> Luxembourg German Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-lu"></span> Luxembourg German Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/088_italian_results.html
+++ b/goodies/vote/088_italian_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Luxembourg Italian Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-lu"></span> Luxembourg Italian Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-lu"></span> Luxembourg Italian Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/094_dutch_results.html
+++ b/goodies/vote/094_dutch_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Netherlands Dutch Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-nl"></span> Netherlands Dutch Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-nl"></span> Netherlands Dutch Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/095_english_results.html
+++ b/goodies/vote/095_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - New Zealand English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-nz"></span> New Zealand English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-nz"></span> New Zealand English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/096_english_results.html
+++ b/goodies/vote/096_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Norway English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-no"></span> Norway English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-no"></span> Norway English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/098_english_results.html
+++ b/goodies/vote/098_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Portugal English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-pt"></span> Portugal English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-pt"></span> Portugal English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/098_portuguese_results.html
+++ b/goodies/vote/098_portuguese_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Portugal Portuguese Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-pt"></span> Portugal Portuguese Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-pt"></span> Portugal Portuguese Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/098_spanish_results.html
+++ b/goodies/vote/098_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Portugal Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-pt"></span> Portugal Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-pt"></span> Portugal Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/105_spanish_results.html
+++ b/goodies/vote/105_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Spain Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-es"></span> Spain Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-es"></span> Spain Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/107_english_results.html
+++ b/goodies/vote/107_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Sweden English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-se"></span> Sweden English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-se"></span> Sweden English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/108_dutch_results.html
+++ b/goodies/vote/108_dutch_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Switzerland Dutch Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ch"></span> Switzerland Dutch Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ch"></span> Switzerland Dutch Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/108_french_results.html
+++ b/goodies/vote/108_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Switzerland French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ch"></span> Switzerland French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ch"></span> Switzerland French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/108_german_results.html
+++ b/goodies/vote/108_german_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Switzerland German Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ch"></span> Switzerland German Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ch"></span> Switzerland German Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/108_italian_results.html
+++ b/goodies/vote/108_italian_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Switzerland Italian Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-ch"></span> Switzerland Italian Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-ch"></span> Switzerland Italian Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/110_english_results.html
+++ b/goodies/vote/110_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - United Kingdom English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><span class="flag-icon flag-icon-gb"></span> United Kingdom English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><span class="flag-icon flag-icon-gb"></span> United Kingdom English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/index.html
+++ b/goodies/vote/index.html
@@ -5,10 +5,10 @@ title: Everybody Votes Channel Poll Results
 	<div class="section no-pad-bot">
 		<div class="container">
 			<br><br>
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text">Poll Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center">Poll Results</h2>
 			<div class="row center">
-				<h5 class="header col s12 light">You can find poll results from all polls in the Everybody Votes Channel here.</h5>
+				<h5 class="header col s12">You can find poll results from all polls in the Everybody Votes Channel here.</h5>
 			</div>
 			<br><br>
 		</div>

--- a/goodies/vote/nintendo.html
+++ b/goodies/vote/nintendo.html
@@ -6,10 +6,10 @@ title: Everybody Votes Channel Poll Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text">Poll Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center">Poll Results</h2>
 			<div class="row center">
-				<h5 class="header col s12 light">You can find poll results from all polls in the Everybody Votes Channel here. Each page is very long, but you can use Control/Command + F on your computer to look for a poll you want to see results for.</h5>
+				<h5 class="header col s12">You can find poll results from all polls in the Everybody Votes Channel here. Each page is very long, but you can use Control/Command + F on your computer to look for a poll you want to see results for.</h5>
 			</div>
 			<br><br>
 		</div>

--- a/goodies/vote/world_dutch_results.html
+++ b/goodies/vote/world_dutch_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Worldwide Dutch Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide Dutch Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide Dutch Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/world_english_results.html
+++ b/goodies/vote/world_english_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Worldwide English Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide English Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide English Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/world_french_canada_results.html
+++ b/goodies/vote/world_french_canada_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Worldwide French Canada Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide French Canada Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide French Canada Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/world_french_results.html
+++ b/goodies/vote/world_french_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Worldwide French Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide French Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide French Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/world_german_results.html
+++ b/goodies/vote/world_german_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Worldwide German Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide German Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide German Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/world_italian_results.html
+++ b/goodies/vote/world_italian_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Worldwide Italian Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide Italian Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide Italian Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/world_japanese_results.html
+++ b/goodies/vote/world_japanese_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Worldwide Japanese Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide Japanese Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide Japanese Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/world_portuguese_results.html
+++ b/goodies/vote/world_portuguese_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Worldwide Portuguese Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide Portuguese Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide Portuguese Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/vote/world_spanish_results.html
+++ b/goodies/vote/world_spanish_results.html
@@ -5,8 +5,8 @@ title: Everybody Votes Channel - Worldwide Spanish Results
 		<div class="container">
 			<br><br>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.8.0/css/flag-icon.min.css" />
-			<h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
-			<h2 class="header center white-text"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide Spanish Results</h2>
+			<h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+			<h2 class="header center"><i class="fas fa-globe" aria-hidden="true"></i> Worldwide Spanish Results</h2>
 			<br><br>
 		</div>
 	</div>

--- a/goodies/wallpapers/index.html
+++ b/goodies/wallpapers/index.html
@@ -4,9 +4,9 @@ title: Wallpaper Downloads
 	<div class="section no-pad-bot">
 		<div class="container">
 			<br><br>
-			<h1 class="header center white-text"><i class="fas fa-download" aria-hidden="true"></i> Wallpaper Downloads</h1>
+			<h1 class="header center"><i class="fas fa-download" aria-hidden="true"></i> Wallpaper Downloads</h1>
 			<div class="row center">
-				<h5 class="header col s12 light">Here's our collection of wallpapers you can download.</h5>
+				<h5 class="header col s12">Here's our collection of wallpapers you can download.</h5>
 			</div>
 			<br><br>
 		</div>

--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@ title: RiiConnect24
   <div class="section no-pad-bot">
     <div class="col s6">
       <br><br>
-      <h1 class="header center white-text">RiiConnect your Wii.</h1>
+      <h1 class="header center">RiiConnect your Wii.</h1>
       <div class="row center">
-        <h5 class="header col s12 light white-text center">RiiConnect24 brings back WiiConnect24, making your Wii more
+        <h5 class="header col s12 center">RiiConnect24 brings back WiiConnect24, making your Wii more
           lively.</h5>
         <a href="https://wii.guide/riiconnect24" id="download-button"
           class="btn-large waves-effect waves-light blue lighten-1">How
@@ -47,7 +47,7 @@ title: RiiConnect24
 </div>
 
 <div class="section center">
-  <h3 class="header center white-text"><i class="fas fa-cogs" aria-hidden="true"></i> Services</h3>
+  <h3 class="header center"><i class="fas fa-cogs" aria-hidden="true"></i> Services</h3>
 
   <p class="light center">Here are the services that RiiConnect24 allows you to use.</p>
 
@@ -56,10 +56,10 @@ title: RiiConnect24
     <div class="col s12 m4">
       <div class="icon-block">
         <a href="/services/forecast.html">
-          <h2 class="center white-text"><i class="fas fa-sun" aria-hidden="true"></i></h2>
+          <h2 class="center header"><i class="fas fa-sun" aria-hidden="true"></i></h2>
           <h5 class="center">Forecast Channel</h5>
 
-          <p class="light white-text">Get local and worldwide weather on your Wii. You can see the weather around
+          <p class="light">Get local and worldwide weather on your Wii. You can see the weather around
             the
             world on a virtual globe.</p>
         </a>
@@ -69,10 +69,10 @@ title: RiiConnect24
     <div class="col s12 m4">
       <div class="icon-block">
         <a href="/services/news.html">
-          <h2 class="center white-text"><i class="fas fa-newspaper" aria-hidden="true"></i></h2>
+          <h2 class="center header"><i class="fas fa-newspaper" aria-hidden="true"></i></h2>
           <h5 class="center">News Channel</h5>
 
-          <p class="light white-text">Get national and worldwide news on your Wii. You can see the news around the
+          <p class="light">Get national and worldwide news on your Wii. You can see the news around the
             world on a virtual globe or in a slideshow.</p>
         </a>
       </div>
@@ -81,10 +81,10 @@ title: RiiConnect24
     <div class="col s12 m4">
       <div class="icon-block">
         <a href="/services/votes.html">
-          <h2 class="center white-text"><i class="fas fa-comments" aria-hidden="true"></i></h2>
+          <h2 class="center header"><i class="fas fa-comments" aria-hidden="true"></i></h2>
           <h5 class="center">Everybody Votes Channel</h5>
 
-          <p class="light white-text">Vote on fun polls and see what the RiiConnect24 community has voted on.</p>
+          <p class="light">Vote on fun polls and see what the RiiConnect24 community has voted on.</p>
         </a>
       </div>
     </div>
@@ -94,10 +94,10 @@ title: RiiConnect24
     <div class="col s12 m4">
       <div class="icon-block">
         <a href="/services/nintendo.html">
-          <h2 class="center white-text"><i class="fas fa-film" aria-hidden="true"></i></h2>
+          <h2 class="center header"><i class="fas fa-film" aria-hidden="true"></i></h2>
           <h5 class="center">Nintendo Channel</h5>
 
-          <p class="light white-text">Send demos to a DS system and watch videos such as the Nintendo Week series.
+          <p class="light">Send demos to a DS system and watch videos such as the Nintendo Week series.
           </p>
         </a>
       </div>
@@ -106,10 +106,10 @@ title: RiiConnect24
     <div class="col s12 m4">
       <div class="icon-block">
         <a href="/services/mail.html">
-          <h2 class="center white-text"><i class="fas fa-envelope" aria-hidden="true"></i></h2>
+          <h2 class="center header"><i class="fas fa-envelope" aria-hidden="true"></i></h2>
           <h5 class="center">Wii Mail</h5>
 
-          <p class="light white-text">Send messages or game data to other people connected to RiiConnect24.</p>
+          <p class="light">Send messages or game data to other people connected to RiiConnect24.</p>
         </a>
       </div>
     </div>
@@ -117,10 +117,10 @@ title: RiiConnect24
     <div class="col s12 m4">
       <div class="icon-block">
         <a href="/services/miicontest.html">
-          <h2 class="center white-text"><i class="fas fa-smile" aria-hidden="true"></i></h2>
+          <h2 class="center header"><i class="fas fa-smile" aria-hidden="true"></i></h2>
           <h5 class="center">Check Mii Out Channel</h5>
 
-          <p class="light white-text">Share Miis with the community and enter them in contests.</p>
+          <p class="light">Share Miis with the community and enter them in contests.</p>
         </a>
       </div>
     </div>
@@ -130,10 +130,10 @@ title: RiiConnect24
     <div class="col s12 m4">
       <div class="icon-block">
         <a href="/services/riitube.html">
-          <h2 class="center white-text"><i class="fas fa-video" aria-hidden="true"></i></h2>
+          <h2 class="center header"><i class="fas fa-video" aria-hidden="true"></i></h2>
           <h5 class="center">RiiTube</h5>
 
-          <p class="light white-text">Watch YouTube and other video streaming platforms on your Wii.</p>
+          <p class="light">Watch YouTube and other video streaming platforms on your Wii.</p>
         </a>
       </div>
     </div>
@@ -141,10 +141,10 @@ title: RiiConnect24
     <div class="col s12 m4">
       <div class="icon-block">
         <a href="https://tag.rc24.xyz/">
-          <h2 class="center white-text"><i class="fas fa-tag" aria-hidden="true"></i></h2>
+          <h2 class="center header"><i class="fas fa-tag" aria-hidden="true"></i></h2>
           <h5 class="center">RiiTag</h5>
 
-          <p class="light white-text">Share what you've been playing to your friends with a gamertag which supports
+          <p class="light">Share what you've been playing to your friends with a gamertag which supports
             modern Nintendo devices.</p>
         </a>
       </div>
@@ -153,10 +153,10 @@ title: RiiConnect24
     <div class="col s12 m4">
       <div class="icon-block">
         <a href="/services/bot.html">
-          <h2 class="center white-text"><i class="fab fa-discord" aria-hidden="true"></i></h2>
+          <h2 class="center header"><i class="fab fa-discord" aria-hidden="true"></i></h2>
           <h5 class="center">RiiConnect24 Bot</h5>
 
-          <p class="light white-text">Share your friend codes and other information with our own Discord bot.</p>
+          <p class="light">Share your friend codes and other information with our own Discord bot.</p>
         </a>
       </div>
     </div>
@@ -166,7 +166,7 @@ title: RiiConnect24
 <div class="section center">
   <div class="row">
     <div class="col s12">
-      <h3 class="header center white-text"><i class="fas fa-question-circle" aria-hidden="true"></i> Why use
+      <h3 class="header center"><i class="fas fa-question-circle" aria-hidden="true"></i> Why use
         RiiConnect24?</h3>
 
       <p class="light">
@@ -187,7 +187,7 @@ title: RiiConnect24
 <div class="section center">
   <div class="row">
     <div class="col s12">
-      <h3 class="header center white-text"><i class="fab fa-discord" aria-hidden="true"></i> Discord</h3>
+      <h3 class="header center"><i class="fab fa-discord" aria-hidden="true"></i> Discord</h3>
 
       <style>
         .discord {

--- a/services/bot.html
+++ b/services/bot.html
@@ -5,9 +5,9 @@ title: RiiConnect24 Bot
 	<div class="section no-pad-bot">
 		<div class="container">
 			<br><br>
-			<h1 class="header center white-text"><i class="fab fa-discord" aria-hidden="true"></i> RiiConnect24 Bot</h1>
+			<h1 class="header center"><i class="fab fa-discord" aria-hidden="true"></i> RiiConnect24 Bot</h1>
 			<div class="row center">
-				<h5 class="header col s12 light">Look up error codes and exchange friend codes with other users.</h5>
+				<h5 class="header col s12">Look up error codes and exchange friend codes with other users.</h5>
 				<a href="https://bot.rc24.xyz/" id="download-button" class="btn-large waves-effect waves-light blue lighten-1">Invite to Server</a>
 			</div>
 			<br><br>

--- a/services/digicam.html
+++ b/services/digicam.html
@@ -5,9 +5,9 @@ title: Digicam Print Channel
 <div class="section no-pad-bot">
   <div class="container">
     <br><br>
-    <h1 class="header center white-text"><i class="fas fa-camera" aria-hidden="true"></i> Digicam Print Channel</h1>
+    <h1 class="header center"><i class="fas fa-camera" aria-hidden="true"></i> Digicam Print Channel</h1>
     <div class="row center">
-      <h5 class="header col s12 light">This service has been brought back thanks to <a
+      <h5 class="header col s12">This service has been brought back thanks to <a
           href="https://www.wiilink24.com">WiiLink</a>.</h5>
       <img src="/images/wiimenu/digicam.png" alt="Digicam" />
     </div>

--- a/services/food.html
+++ b/services/food.html
@@ -5,9 +5,9 @@ title: Demae Channel
 <div class="section no-pad-bot">
   <div class="container">
     <br><br>
-    <h1 class="header center white-text"><i class="fas fa-utensils" aria-hidden="true"></i> Demae Channel</h1>
+    <h1 class="header center"><i class="fas fa-utensils" aria-hidden="true"></i> Demae Channel</h1>
     <div class="row center">
-      <h5 class="header col s12 light">This service has been brought back thanks to <a
+      <h5 class="header col s12">This service has been brought back thanks to <a
           href="https://www.wiilink24.com">WiiLink</a>.</h5>
       <img src="/images/wiimenu/foodguy.png" alt="Food Guy" />
     </div>

--- a/services/forecast.html
+++ b/services/forecast.html
@@ -5,9 +5,9 @@ title: Forecast Channel
 <div class="section no-pad-bot">
   <div class="container">
     <br><br>
-    <h1 class="header center white-text"><i class="fas fa-sun" aria-hidden="true"></i> Forecast Channel</h1>
+    <h1 class="header center"><i class="fas fa-sun" aria-hidden="true"></i> Forecast Channel</h1>
     <div class="row center">
-      <h5 class="header col s12 light">Check the local and international forecasts on your Wii.</h5>
+      <h5 class="header col s12">Check the local and international forecasts on your Wii.</h5>
     </div>
     <audio autoplay>
       <source src="/sounds/wiimenu/forecast.wav" type="audio/wav">
@@ -34,7 +34,7 @@ title: Forecast Channel
     <div class="container">
       <div class="row center">
         <div class="col s12">
-          <h4 class="white-text"><i class="fab fa-youtube" aria-hidden="true"></i> Watch Video</h4>
+          <h4><i class="fab fa-youtube" aria-hidden="true"></i> Watch Video</h4>
           <div class="video-container">
             <iframe src="https://www.youtube.com/embed/z1xj3zVM-Ds" frameborder="0" allow="autoplay; encrypted-media"
               allowfullscreen></iframe>

--- a/services/gamenight.html
+++ b/services/gamenight.html
@@ -5,9 +5,9 @@ title: Game Nights
 <div class="section no-pad-bot">
 	<div class="container">
 		<br><br>
-		<h1 class="header center white-text"><i class="fas fa-gamepad" aria-hidden="true"></i> Game Night</h1>
+		<h1 class="header center"><i class="fas fa-gamepad" aria-hidden="true"></i> Game Night</h1>
 		<div class="row center">
-			<h5 class="header col s12 light">Play a Wii game on Wiimmfi every week.</h5>
+			<h5 class="header col s12">Play a Wii game on Wiimmfi every week.</h5>
 			<a href="https://discord.gg/rc24" id="download-button"
 				class="btn-large waves-effect waves-light blue lighten-1">Discord Invite</a>
 		</div>

--- a/services/kirby.html
+++ b/services/kirby.html
@@ -5,9 +5,9 @@ title: Kirby TV Channel
 <div class="section no-pad-bot">
   <div class="container">
     <br><br>
-    <h1 class="header center white-text"><i class="fas fa-tv" aria-hidden="true"></i> Kirby TV Channel</h1>
+    <h1 class="header center"><i class="fas fa-tv" aria-hidden="true"></i> Kirby TV Channel</h1>
     <div class="row center">
-      <h5 class="header col s12 light">This service has been brought back thanks to <a
+      <h5 class="header col s12">This service has been brought back thanks to <a
           href="https://www.wiilink24.com">WiiLink</a>.</h5>
     </div>
     <audio autoplay>

--- a/services/mail.html
+++ b/services/mail.html
@@ -5,9 +5,9 @@ title: Wii Mail
 	<div class="section no-pad-bot">
 		<div class="container">
 			<br><br>
-			<h1 class="header center white-text"><i class="fas fa-envelope" aria-hidden="true"></i> Wii Mail</h1>
+			<h1 class="header center"><i class="fas fa-envelope" aria-hidden="true"></i> Wii Mail</h1>
 			<div class="row center">
-				<h5 class="header col s12 light">Communicate with other Wiis again.</h5>
+				<h5 class="header col s12">Communicate with other Wiis again.</h5>
 				<img src="/images/wiimenu/letteryellow.png" alt="Letter">
 				<br>
 				<a href="/stats/mail.html" id="download-button" class="btn-large waves-effect waves-light blue lighten-1">List of Tested Games</a>

--- a/services/miicontest.html
+++ b/services/miicontest.html
@@ -5,10 +5,10 @@ title: Check Mii Out Channel/Mii Contest Channel
 <div class="section no-pad-bot">
   <div class="container">
     <br><br>
-    <h1 class="header center white-text"><i class="fas fa-smile" aria-hidden="true"></i> Check Mii Out Channel/Mii
+    <h1 class="header center"><i class="fas fa-smile" aria-hidden="true"></i> Check Mii Out Channel/Mii
       Contest Channel</h1>
     <div class="row center">
-      <h5 class="header col s12 light">Share Miis with the community and enter them in contests.</h5>
+      <h5 class="header col s12">Share Miis with the community and enter them in contests.</h5>
       <br>
       <a href="https://mii.rc24.xyz/" id="download-button"
         class="btn-large waves-effect waves-light blue lighten-1">View Miis and Stats</a>
@@ -35,7 +35,7 @@ title: Check Mii Out Channel/Mii Contest Channel
     <div class="container">
       <div class="row center">
         <div class="col s12">
-          <h4 class="white-text"><i class="fab fa-youtube" aria-hidden="true"></i> Watch Video</h4>
+          <h4><i class="fab fa-youtube" aria-hidden="true"></i> Watch Video</h4>
           <div class="video-container">
             <iframe src="https://www.youtube.com/embed/O7PhBhvwO-s" frameborder="0" allow="autoplay; encrypted-media"
               allowfullscreen></iframe>

--- a/services/news.html
+++ b/services/news.html
@@ -5,9 +5,9 @@ title: News Channel
 <div class="section no-pad-bot">
 	<div class="container">
 		<br><br>
-		<h1 class="header center white-text"><i class="fas fa-newspaper" aria-hidden="true"></i> News Channel</h1>
+		<h1 class="header center"><i class="fas fa-newspaper" aria-hidden="true"></i> News Channel</h1>
 		<div class="row center">
-			<h5 class="header col s12 light">Read news on your Wii.</h5>
+			<h5 class="header col s12">Read news on your Wii.</h5>
 		</div>
 		<audio autoplay>
 			<source src="/sounds/wiimenu/news.wav" type="audio/wav">
@@ -29,7 +29,7 @@ title: News Channel
 		<br>
 		<div class="row center">
 			<ul class="collection with-header">
-				<li class="collection-header white-text">
+				<li class="collection-header">
 					<h4>List of News Sources</h4>
 				</li>
 				<li class="collection-item">
@@ -83,7 +83,7 @@ title: News Channel
 	<div class="container">
 		<div class="row center">
 			<div class="col s12">
-				<h4 class="white-text"><i class="fab fa-youtube" aria-hidden="true"></i> Watch Video</h4>
+				<h4><i class="fab fa-youtube" aria-hidden="true"></i> Watch Video</h4>
 				<div class="video-container">
 					<iframe src="https://www.youtube.com/embed/zYnexF8UCK0" frameborder="0"
 						allow="autoplay; encrypted-media" allowfullscreen></iframe>

--- a/services/nintendo.html
+++ b/services/nintendo.html
@@ -5,9 +5,9 @@ title: Nintendo Channel
 <div class="section no-pad-bot">
   <div class="container">
     <br><br>
-    <h1 class="header center white-text"><i class="fas fa-film" aria-hidden="true"></i> Nintendo Channel</h1>
+    <h1 class="header center"><i class="fas fa-film" aria-hidden="true"></i> Nintendo Channel</h1>
     <div class="row center">
-      <h5 class="header col s12 light">Watch videos, get information about games, recommend titles, download DS
+      <h5 class="header col s12">Watch videos, get information about games, recommend titles, download DS
         software, and more.</h5>
       <br>
     </div>
@@ -30,7 +30,7 @@ title: Nintendo Channel
     <div class="container">
       <div class="row center">
         <div class="col s12">
-          <h4 class="white-text"><i class="fab fa-youtube" aria-hidden="true"></i> Watch Video</h4>
+          <h4><i class="fab fa-youtube" aria-hidden="true"></i> Watch Video</h4>
           <div class="video-container">
             <iframe src="https://www.youtube.com/embed/Kj9QhiI2bJU" frameborder="0" allow="autoplay; encrypted-media"
               allowfullscreen></iframe>

--- a/services/riitube.html
+++ b/services/riitube.html
@@ -5,9 +5,9 @@ title: RiiTube
 <div class="section no-pad-bot">
 	<div class="container">
 		<br><br>
-		<h1 class="header center white-text"><i class="fas fa-video" aria-hidden="true"></i> RiiTube</h1>
+		<h1 class="header center"><i class="fas fa-video" aria-hidden="true"></i> RiiTube</h1>
 		<div class="row center">
-			<h5 class="header col s12 light">Watch YouTube on your Wii.</h5>
+			<h5 class="header col s12">Watch YouTube on your Wii.</h5>
 			<br>
 			<a href="https://oscwii.org/library/app/wiimc-ss" id="download-button"
 				class="btn-large waves-effect waves-light blue lighten-1">Get WiiMC with RiiTube support</a>
@@ -31,7 +31,7 @@ title: RiiTube
 <div class="section">
 	<div class="container">
 		<div class="row center">
-			<h4 class="white-text"><i class="fas fa-video" aria-hidden="true"></i> Watch Video</i></h4>
+			<h4><i class="fas fa-video" aria-hidden="true"></i> Watch Video</i></h4>
 			<div class="video-container">
 				<iframe src="https://www.youtube.com/embed/16FYndYB3CA" frameborder="0"
 					allow="autoplay; encrypted-media" allowfullscreen></iframe>

--- a/services/room.html
+++ b/services/room.html
@@ -5,9 +5,9 @@ title: Wii no Ma
 <div class="section no-pad-bot">
   <div class="container">
     <br><br>
-    <h1 class="header center white-text"><i class="fas fa-home" aria-hidden="true"></i> Wii no Ma</h1>
+    <h1 class="header center"><i class="fas fa-home" aria-hidden="true"></i> Wii no Ma</h1>
     <div class="row center">
-      <h5 class="header col s12 light">This service has been brought back thanks to <a
+      <h5 class="header col s12">This service has been brought back thanks to <a
           href="https://www.wiilink24.com">WiiLink</a>.</h5>
       <img src="/images/wiimenu/table.png" alt="Table" />
     </div>

--- a/services/rssmii.html
+++ b/services/rssmii.html
@@ -5,9 +5,9 @@ title: RSSMii
 	<div class="section no-pad-bot">
 		<div class="container">
 			<br><br>
-			<h1 class="header center white-text"><i class="fas fa-rss-square" aria-hidden="true"></i> RSSMii</h1>
+			<h1 class="header center"><i class="fas fa-rss-square" aria-hidden="true"></i> RSSMii</h1>
 			<div class="row center">
-				<h5 class="header col s12 light">Get RSS updates on your Wii.</h5>
+				<h5 class="header col s12">Get RSS updates on your Wii.</h5>
 				<img src="/images/rssmii/rssmii.png" alt="RSSMii">
 				<br>
 				<a href="https://wii.guide/rssmii" id="download-button" class="btn-large waves-effect waves-light blue lighten-1">How to Install</a>

--- a/services/speak.html
+++ b/services/speak.html
@@ -5,9 +5,9 @@ title: Wii Speak Channel
   <div class="section no-pad-bot">
     <div class="container">
       <br><br>
-      <h1 class="header center white-text"><i class="fas fa-microphone" aria-hidden="true"></i> Wii Speak Channel</h1>
+      <h1 class="header center"><i class="fas fa-microphone" aria-hidden="true"></i> Wii Speak Channel</h1>
       <div class="row center">
-        <h5 class="header col s12 light">Voice chat with people on your Wii.</h5>
+        <h5 class="header col s12">Voice chat with people on your Wii.</h5>
         <br>
         <img src="/images/wiimenu/speak.png" alt="Speak" />
         <br>

--- a/services/television.html
+++ b/services/television.html
@@ -5,10 +5,10 @@ title: TV no Tomo Channel G Guide for Wii
 <div class="section no-pad-bot">
   <div class="container">
     <br><br>
-    <h1 class="header center white-text"><i class="fas fa-tv" aria-hidden="true"></i> TV no Tomo Channel G Guide for Wii
+    <h1 class="header center"><i class="fas fa-tv" aria-hidden="true"></i> TV no Tomo Channel G Guide for Wii
     </h1>
     <div class="row center">
-      <h5 class="header col s12 light">This service is currently being worked on thanks to <a
+      <h5 class="header col s12">This service is currently being worked on thanks to <a
           href="https://www.wiilink24.com">WiiLink</a>.</h5>
       <img src="/images/wiimenu/tvstamp.png" alt="TV Stamp" />
     </div>

--- a/services/votes.html
+++ b/services/votes.html
@@ -5,9 +5,9 @@ title: Everybody Votes Channel
 <div class="section no-pad-bot">
   <div class="container">
     <br><br>
-    <h1 class="header center white-text"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
+    <h1 class="header center"><i class="fas fa-comments" aria-hidden="true"></i> Everybody Votes Channel</h1>
     <div class="row center">
-      <h5 class="header col s12 light">Answer questions and tell the world your answer in national and worldwide polls.
+      <h5 class="header col s12">Answer questions and tell the world your answer in national and worldwide polls.
       </h5>
       <br>
       <a href="https://rc24.xyz/goodies/vote/" id="download-button"
@@ -34,7 +34,7 @@ title: Everybody Votes Channel
     <div class="container">
       <div class="row center">
         <div class="col s12">
-          <h4 class="white-text"><i class="fab fa-youtube" aria-hidden="true"></i> Watch Video</h4>
+          <h4><i class="fab fa-youtube" aria-hidden="true"></i> Watch Video</h4>
           <div class="video-container">
             <iframe src="https://www.youtube.com/embed/tAwTZBC3Py8" frameborder="0" allow="autoplay; encrypted-media"
               allowfullscreen></iframe>

--- a/stats/forecast.html
+++ b/stats/forecast.html
@@ -5,9 +5,9 @@ title: Stats - Forecast Channel
 	<div class="section no-pad-bot">
 		<div class="container">
 			<br><br>
-			<h1 class="header center white-text"><i class="fas fa-chart-bar" aria-hidden="true"></i> List of Games that work with the Forecast Channel</h1>
+			<h1 class="header center"><i class="fas fa-chart-bar" aria-hidden="true"></i> List of Games that work with the Forecast Channel</h1>
 			<div class="row center">
-				<h5 class="header col s12 light">This tells you which games are currently working with the Forecast Channel. If it's working, the game will make use of the latest forecast in-game.</h5>
+				<h5 class="header col s12">This tells you which games are currently working with the Forecast Channel. If it's working, the game will make use of the latest forecast in-game.</h5>
 			</div>
 			<audio autoplay>
 				<source src="/sounds/wiimenureserved.wav" type="audio/wav">

--- a/stats/index.html
+++ b/stats/index.html
@@ -6,9 +6,9 @@ title: Stats
 <div class="section no-pad-bot">
 	<div class="container">
 		<br><br>
-		<h1 class="header center white-text"><i class="fas fa-chart-bar" aria-hidden="true"></i> Stats</h1>
+		<h1 class="header center"><i class="fas fa-chart-bar" aria-hidden="true"></i> Stats</h1>
 		<div class="row center">
-			<h5 class="header col s12 light">This page lists what services are offered with RiiConnect24 and its
+			<h5 class="header col s12">This page lists what services are offered with RiiConnect24 and its
 				affiliates.</h5>
 			<a href="https://status.rc24.xyz/" id="download-button"
 				class="btn-large waves-effect waves-light blue lighten-1">Current Server Status</a>
@@ -28,7 +28,7 @@ title: Stats
 					<h4>Stats</h4>
 				</li>
 				<li class="collection-item">
-					<h5 class="light">Animal Crossing: City Folk DLC</h5>
+					<h5><span class="light">Animal Crossing: City Folk DLC</span></h5>
 				</li>
 				<li class="collection-item">
 					<h5><a href="/services/miicontest.html" class="blue-text text-darken-2">Check Mii Out Channel/Mii
@@ -88,7 +88,7 @@ title: Stats
 					<h5><a href="/services/mail.html" class="blue-text text-darken-2">Wii Mail</a></h5>
 				</li>
 				<li class="collection-item">
-					<h5 class="light">Wii Message Board Announcements</h5>
+					<h5><span class="light">Wii Message Board Announcements</span></h5>
 				</li>
 				<li class="collection-item">
 					<h5><a href="/services/room.html" class="blue-text text-darken-2">Wii no Ma</a></h5>

--- a/stats/mail.html
+++ b/stats/mail.html
@@ -5,9 +5,9 @@ title: Stats - Mail
 	<div class="section no-pad-bot">
 		<div class="container">
 			<br><br>
-			<h1 class="header center white-text"><i class="fas fa-chart-bar" aria-hidden="true"></i> List of Games/Apps using Wii Mail</h1>
+			<h1 class="header center"><i class="fas fa-chart-bar" aria-hidden="true"></i> List of Games/Apps using Wii Mail</h1>
 			<div class="row center">
-				<h5 class="header col s12 light">This tells you which games work with Wii Mail.</h5>
+				<h5 class="header col s12">This tells you which games work with Wii Mail.</h5>
 			</div>
 			<audio autoplay>
 				<source src="/sounds/wiimenureserved.wav" type="audio/wav">


### PR DESCRIPTION
* fix horizontal scrollbar always being on the screen
* refactor style.css
* greatly simplify a lot of classes (i.e. remove white-text because it's functionally exactly the same as .light but more confusing)
* fix 2 codefactor issues in card-title styling

Visually everything should look exactly the same as it does now in both dark and light modes.

I actually just wanted to limit width of the page so text doesn't go from one side of the screen to another on wide displays, but I got quickly distracted trying to make sense of current CSS.