### PR TITLE
Add rel="me" to Mastodon

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,7 +26,7 @@
 						<a class="white-text" href="https://www.instagram.com/RiiConnect24">Instagram</a>
 					</li>
 					<li class="linkbtn"><i class="fab fa-mastodon" aria-hidden="true"></i>
-						<a class="white-text" href="https://mastodon.social/@RiiConnect24">Mastodon</a>
+						<a class="white-text" rel="me" href="https://mastodon.social/@RiiConnect24">Mastodon</a>
 					</li>
 					<li class="linkbtn"><i class="fab fa-github" aria-hidden="true"></i>
 						<a class="white-text" href="https://github.com/RiiConnect24">GitHub</a>


### PR DESCRIPTION
This allows the Mastodon profile to have a verified link on it, proving that the profile is authentic