### PR TITLE
Update hyperlinks for Wii guide changes

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,7 +6,7 @@
 				<ul class="right hide-on-med-and-down">
 					<li><a id="nav-item" href="/about.html"><i class="fas fa-info-circle" aria-hidden="true"></i> About</a></li>
 					<li><a id="nav-item" href="/faq.html"><i class="fas fa-question-circle" aria-hidden="true"></i> FAQ</a></li>
-					<li><a id="nav-item" href="https://wii.guide/riiconnect24"><i class="fa-solid fa-book"></i> Guide</a></li>
+					<li><a id="nav-item" href="https://www.wiilink24.com/guide/install/"><i class="fa-solid fa-book"></i> Guide</a></li>
 					<li><a id="nav-item" href="/stats/index.html"><i class="fa-solid fa-list"></i> Stats</a></li>
 					<li><a id="nav-item" href="/goodies/index.html"><i class="fa-solid fa-box"></i> Goodies</a></li>
 				</ul>
@@ -15,7 +15,7 @@
 <ul class="sidenav" id="mobile">
 	<li><a href="/about.html"><i class="fas fa-info-circle" aria-hidden="true"></i> About</a></li>
 	<li><a href="/faq.html"><i class="fas fa-question-circle" aria-hidden="true"></i> FAQ</a></li>
-	<li><a href="https://wii.guide/riiconnect24"><i class="fas fa-list" aria-hidden="true"></i> Guide</a></li>
+	<li><a href="https://www.wiilink24.com/guide/install/"><i class="fas fa-list" aria-hidden="true"></i> Guide</a></li>
 	<li><a href="/stats/index.html"><i class="fas fa-chart-bar" aria-hidden="true"></i> Stats</a></li>
 	<li><a href="/goodies/index.html"><i class="fas fa-gift" aria-hidden="true"></i> Goodies</a></li>
 </ul>

--- a/_includes/parallax_nav.html
+++ b/_includes/parallax_nav.html
@@ -5,7 +5,7 @@
         <ul class="left hide-on-med-and-down">
             <li><a id="nav-item" href="/about.html"><i class="fas fa-info-circle" aria-hidden="true"></i> About</a></li>
             <li><a id="nav-item" href="/faq.html"><i class="fas fa-question-circle" aria-hidden="true"></i> FAQ</a></li>
-            <li><a id="nav-item" href="https://wii.guide/riiconnect24"><i class="fa-solid fa-book"></i> Guide</a></li>
+            <li><a id="nav-item" href="https://www.wiilink24.com/guide/install/"><i class="fa-solid fa-book"></i> Guide</a></li>
             <li><a id="nav-item" href="/stats/index.html"><i class="fa-solid fa-list"></i> Stats</a></li>
             <li><a id="nav-item" href="/goodies/index.html"><i class="fa-solid fa-box"></i> Goodies</a></li>
         </ul>
@@ -14,7 +14,7 @@
     <ul class="sidenav" id="mobile">
         <li><a href="/about.html"><i class="fas fa-info-circle" aria-hidden="true"></i> About</a></li>
         <li><a href="/faq.html"><i class="fas fa-question-circle" aria-hidden="true"></i> FAQ</a></li>
-        <li><a href="https://wii.guide/riiconnect24"><i class="fas fa-list" aria-hidden="true"></i> Guide</a></li>
+        <li><a href="https://www.wiilink24.com/guide/install/"><i class="fas fa-list" aria-hidden="true"></i> Guide</a></li>
         <li><a href="/stats/index.html"><i class="fas fa-chart-bar" aria-hidden="true"></i> Stats</a></li>
         <li><a href="/goodies/index.html"><i class="fas fa-gift" aria-hidden="true"></i> Goodies</a></li>
     </ul>

--- a/faq.html
+++ b/faq.html
@@ -35,8 +35,9 @@ title: FAQ
 			<p>Check our <a href="/stats/index.html">stats page</a> for information on our services that we have brought
 				back.</p>
 			<p><b>Q: Does RiiConnect24 work on Dolphin Emulator?</b></p>
-			<p>Yes. However, Wii Mail does not work. Follow <a href="https://wii.guide/riiconnect24-dolphin">this
-					guide</a> to install RiiConnect24 on Dolphin.</p>
+			<p>Following the merger of RiiConnect24 and WiiLink, you can utilize RiiConnect24 services on Dolphin 
+				(including Wii Mail) by enabling WiiLink24 in the Dolphin settings. See the <a href="https://www.wiilink24.com">WiiLink website</a>
+				for further information.</p>
 			<p><b>Q: What's the meaning behind the name of the service?</b></p>
 			<p>Our name is a pun on the WiiConnect24 name, as we are "re-connecting" you to WiiConnect24.</p>
 			<p><b>Q: How can I help out with RiiConnect24?</b></p>

--- a/goodies/themes/index.html
+++ b/goodies/themes/index.html
@@ -115,7 +115,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="rc24_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 					</div>
 				</div>
 			</div>
@@ -130,7 +130,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="rc24_red_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 						<a href="https://imgur.com/a/rGrlf3Y">Screenshots</a>
 					</div>
 				</div>
@@ -219,7 +219,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="https://website.burrito.software/ANY_DarkWii_Plus_v7.mym">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 					</div>
 				</div>
 			</div>
@@ -234,7 +234,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="animal_crossing_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 					</div>
 				</div>
 			</div>
@@ -249,7 +249,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="check_mii_out_channel_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 						<a href="https://imgur.com/a/ay7sDM8">Screenshots</a>
 					</div>
 				</div>
@@ -267,7 +267,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="discord_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 					</div>
 				</div>
 			</div>
@@ -282,7 +282,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="kirby_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 					</div>
 				</div>
 			</div>
@@ -297,7 +297,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="mkw_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 					</div>
 				</div>
 			</div>
@@ -314,7 +314,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="pikmin_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 						<a href="https://imgur.com/a/8dB8hgs">Screenshots</a>
 					</div>
 				</div>
@@ -330,7 +330,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="rhythm_heaven_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 						<a href="https://imgur.com/a/UVkQQHk">Screenshots</a>
 					</div>
 				</div>
@@ -346,7 +346,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="warioware_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 					</div>
 				</div>
 			</div>
@@ -363,7 +363,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="wii_fit_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 					</div>
 				</div>
 			</div>
@@ -378,7 +378,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="wii_sports_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 					</div>
 				</div>
 			</div>
@@ -393,7 +393,7 @@ title: Theme Downloads
 					</div>
 					<div class="card-action">
 						<a href="wii_u_wii_menu_theme.zip">Download</a>
-						<a href="https://wii.guide/themes">How to Install</a>
+						<a href="https://wii.hacks.guide/themes">How to Install</a>
 						<a href="https://imgur.com/a/nJDramU">Screenshots</a>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ title: RiiConnect24
       <div class="row center">
         <h5 class="header col s12 center" style="margin-bottom:38px;">RiiConnect24 brings back WiiConnect24, making your Wii more
           lively.</h5>
-        <a href="https://wii.guide/riiconnect24" id="download-button"
+        <a href="https://www.wiilink24.com/guide/install/" id="download-button"
           class="btn-large waves-effect waves-light blue lighten-1" style="margin:8px; border-radius: 8px;"><i class="fa-solid fa-circle-question" style="font-size:20px;"></i> How
           to
           Connect</a>

--- a/instructions/index.html
+++ b/instructions/index.html
@@ -1,3 +1,3 @@
 <html>
-  <meta http-equiv="refresh" content="0; url=https://wii.guide/" />
+  <meta http-equiv="refresh" content="0; url=https://wii.hacks.guide/" />
 </html>

--- a/instructions/wii.html
+++ b/instructions/wii.html
@@ -1,3 +1,3 @@
 <html>
-  <meta http-equiv="refresh" content="0; url=https://wii.guide/" />
+  <meta http-equiv="refresh" content="0; url=https://wii.hacks.guide/" />
 </html>

--- a/instructions/wiiu.html
+++ b/instructions/wiiu.html
@@ -1,3 +1,3 @@
 <html>
-  <meta http-equiv="refresh" content="0; url=https://wii.guide/" />
+  <meta http-equiv="refresh" content="0; url=https://wii.hacks.guide/" />
 </html>

--- a/instructions/wiiu.html
+++ b/instructions/wiiu.html
@@ -1,3 +1,3 @@
 <html>
-  <meta http-equiv="refresh" content="0; url=https://wii.hacks.guide/" />
+  <meta http-equiv="refresh" content="0; url=https://wiiu.hacks.guide/" />
 </html>

--- a/services/rssmii.html
+++ b/services/rssmii.html
@@ -8,7 +8,7 @@ title: RSSMii
 			<h1 class="header center"><i class="fas fa-rss-square" aria-hidden="true"></i> RSSMii</h1>
 			<div class="row center">
 				<h5 class="header col s12">Get RSS updates on your Wii.</h5>
-				<a href="https://wii.guide/rssmii" id="download-button" class="btn-large waves-effect waves-light blue lighten-1" style="display: flex; align-items: center; justify-content: center; position: relative;"><img src="/images/rssmii/rssmii.png" alt="RSSMii" style="border-radius:6px; margin-right:5px;" height="30px"> How to Install</a>
+				<a href="https://wii.hacks.guide/rssmii" id="download-button" class="btn-large waves-effect waves-light blue lighten-1" style="display: flex; align-items: center; justify-content: center; position: relative;"><img src="/images/rssmii/rssmii.png" alt="RSSMii" style="border-radius:6px; margin-right:5px;" height="30px"> How to Install</a>
 			</div>
 		</div>
 	</div>

--- a/stats/mail.html
+++ b/stats/mail.html
@@ -215,7 +215,7 @@ title: Stats - Mail
 						<h5>Wii Music</h5>
 						<b>Exchange: </b> Video clips<br>
 						<br>
-						<b>Note: </b> <a style="color: #0072ab" href="https://wii.guide/assets/files/brainslug-wii.zip">The game must be launched from the disc with this copy of BrainSlug to work.</a>
+						<b>Note: </b> <a style="color: #0072ab" href="https://wii.hacks.guide/assets/files/brainslug-wii.zip">The game must be launched from the disc with this copy of BrainSlug to work.</a>
 					</li>
 			  </ul>
 			</div>


### PR DESCRIPTION
- Point to WiiLink guide for installation
    - Note, Dolphin guide link remains broken, but that has been the case for quite a while now
- Switch wii.guide to wii.hacks.guide
- Switch wiiu instructions to wiiu.hacks.guide (where is this even used...)

NOTE: this PR supersedes #81, as I didn't see it before I made the changes that one already did. It would cause a merge conflict anyway.